### PR TITLE
added h265 + vp9 encoders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,15 +39,20 @@ set(NODE_NAME ${PROJECT_NAME}_node)
 
 add_executable(
   ${NODE_NAME}
-  src/main.cpp
   src/Driver.cpp
+  src/DriveworksApiWrapper.cpp
   src/cameras/CameraBase.cpp
   src/cameras/CameraH264.cpp
+  src/cameras/CameraH265.cpp
   src/cameras/CameraJpg.cpp
-  src/DriveworksApiWrapper.cpp
-  src/log.cpp
-  src/encoders/NvMediaJpgEncoder.cpp
+  src/cameras/CameraVp9.cpp
+  src/cameras/CameraVp9.cpp
   src/encoders/NvMediaH264Encoder.cpp
+  src/encoders/NvMediaH265Encoder.cpp
+  src/encoders/NvMediaJpgEncoder.cpp
+  src/encoders/NvMediaVp9Encoder.cpp
+  src/log.cpp
+  src/main.cpp
   src/processors/ImageTransformer.cpp)
 
 target_link_libraries(${NODE_NAME} ${catkin_LIBRARIES} nvmedia driveworks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ add_executable(
   src/cameras/CameraH265.cpp
   src/cameras/CameraJpg.cpp
   src/cameras/CameraVp9.cpp
-  src/cameras/CameraVp9.cpp
   src/encoders/NvMediaH264Encoder.cpp
   src/encoders/NvMediaH265Encoder.cpp
   src/encoders/NvMediaJpgEncoder.cpp

--- a/README.md
+++ b/README.md
@@ -209,16 +209,16 @@ roslaunch nvidia_gmsl_driver_ros nvidia_gmsl_driver_ros.launch
 
 ##### Launchfile parameters
 
-| Parameter        |                           Default |                                                       Comment |
-|------------------|----------------------------------:|--------------------------------------------------------------:|
-| `config_path`    | `$(dirname)/../config/ports.yaml` |                                      Path to the config file. |
-| `calib_dir_path` |            `$(dirname)/../calib/` |                          Path to the camera calibration file. |
-| `framerate`      |                              `30` |                                             Output framerate. |
-| `verbose`        |                           `False` |                                       Enables verbose output. | 
-| `encoder`        |                             `jpg` |                                    Encoder. (`jpg` or `h264`) | 
-| `bitrate`        |                         `8000000` | Output bitrate (Minimum `30000`).<br>Only for `encoder=h264`. | 
-| `output_width`   |                            `1920` |                                                 Output width. | 
-| `output_height`  |                            `1208` |                                                Output height. | 
+| Parameter        |                           Default |                                                                             Comment |
+|------------------|----------------------------------:|------------------------------------------------------------------------------------:|
+| `config_path`    | `$(dirname)/../config/ports.yaml` |                                                            Path to the config file. |
+| `calib_dir_path` |            `$(dirname)/../calib/` |                                           Path to the camera calibration directory. |
+| `framerate`      |                              `30` |                                                                   Output framerate. |
+| `verbose`        |                           `False` |                                                             Enables verbose output. | 
+| `encoder`        |                             `jpg` |                       Encoder. <br/>Possible values: {`jpg`, `h264`, `h265`, `vp9`} | 
+| `bitrate`        |                         `8000000` | Output bitrate (Minimum `30000`).<br>Only for `encoder` in {`h264`, `h265`, `vp9`}. | 
+| `output_width`   |                            `1920` |                                                                       Output width. | 
+| `output_height`  |                            `1208` |                                                                      Output height. | 
 
 ### Useful links
 

--- a/include/Driver.h
+++ b/include/Driver.h
@@ -10,7 +10,9 @@
 #include <yaml-cpp/yaml.h>
 
 #include "cameras/CameraH264.h"
+#include "cameras/CameraH265.h"
 #include "cameras/CameraJpg.h"
+#include "cameras/CameraVp9.h"
 #include "exceptions/NvidiaGmslDriverRosFatalException.h"
 #include "exceptions/NvidiaGmslDriverRosMinorException.h"
 #include "framework/thread_pool.hpp"

--- a/include/cameras/CameraBase.h
+++ b/include/cameras/CameraBase.h
@@ -43,11 +43,6 @@ public:
   void start();
 
   /**
-   * @brief Executes once all the steps that the camera implements.
-   */
-  void run_pipeline();
-
-  /**
    * @brief Polls the camera until the buffer is empty. ensuring the frame is the most recent one.
    * @throws NvidiaGmslDriverRosMinorException
    */
@@ -58,6 +53,11 @@ public:
    * @attention Prerequisite : poll()
    */
   void preprocess();
+
+  /**
+   * @brief Has to be overridden. Executes once all the steps that the camera implements.
+   */
+  virtual void run_pipeline() = 0;
 
   /**
    * @brief Has to be overridden. Pushes the polled data (preprocessed or not) to the encoder, then fetches the data.

--- a/include/cameras/CameraH264.h
+++ b/include/cameras/CameraH264.h
@@ -40,6 +40,11 @@ public:
    */
   void publish() override;
 
+  /**
+   * @brief Executes once all the steps that the camera implements.
+   */
+  void run_pipeline() override;
+
   inline static const std::string ENCODER_TYPE = "h264";
 
 private:

--- a/include/cameras/CameraH265.h
+++ b/include/cameras/CameraH265.h
@@ -37,7 +37,16 @@ public:
    * @attention Prerequisite : encode()
    */
   void publish() override;
-  ~CameraH265() override;
+
+  /**
+   * @brief Default constructor.
+   */
+  ~CameraH265() override = default;
+
+  /**
+   * @brief Executes once all the steps that the camera implements.
+   */
+  void run_pipeline() override;
 
   inline static const std::string ENCODER_TYPE = "h265";
 

--- a/include/cameras/CameraH265.h
+++ b/include/cameras/CameraH265.h
@@ -1,0 +1,55 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#pragma once
+
+#include <sensor_msgs/CompressedImage.h>
+
+#include <memory>
+
+#include "cameras/CameraBase.h"
+#include "encoders/NvMediaH265Encoder.h"
+
+class CameraH265 : public CameraBase
+{
+public:
+  /**
+   * @brief Constructor, initializes encoder and h265 image publisher.
+   * @throws NvidiaGmslDriverRosFatalException
+   * @param driveworksApiWrapper
+   * @param config
+   * @param interface
+   * @param link
+   * @param nodehandle
+   */
+  CameraH265(DriveworksApiWrapper* driveworksApiWrapper, const YAML::Node& config, std::string interface,
+             std::string link, ros::NodeHandle* nodehandle);
+
+  /**
+   * @brief Pushes polled data to the encoder. The encoder will then call it's own callback.
+   * @attention Prerequisite : preprocess()
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  void encode() override;
+
+  /**
+   * @brief Publishes compressed images and camera info to ROS.
+   * @attention Prerequisite : encode()
+   */
+  void publish() override;
+  ~CameraH265() override;
+
+  inline static const std::string ENCODER_TYPE = "h265";
+
+private:
+  constexpr static int DEFAULT_BITRATE = 8000000;
+
+  // params
+  int bitrate_;
+
+  ros::Publisher pub_compressed_;
+  std_msgs::Header header_;
+  sensor_msgs::CompressedImage packet_;
+
+  std::unique_ptr<NvMediaH265Encoder> encoder_;
+};

--- a/include/cameras/CameraJpg.h
+++ b/include/cameras/CameraJpg.h
@@ -48,6 +48,11 @@ public:
    */
   void publish() override;
 
+  /**
+   * @brief Executes once all the steps that the camera implements.
+   */
+  void run_pipeline() override;
+
   inline static const std::string ENCODER_TYPE = "jpg";
 
 private:

--- a/include/cameras/CameraVp9.h
+++ b/include/cameras/CameraVp9.h
@@ -38,6 +38,11 @@ public:
    */
   void publish() override;
 
+  /**
+   * @brief Executes once all the steps that the camera implements.
+   */
+  void run_pipeline() override;
+
   inline static const std::string ENCODER_TYPE = "vp9";
 
 private:

--- a/include/cameras/CameraVp9.h
+++ b/include/cameras/CameraVp9.h
@@ -1,0 +1,54 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#pragma once
+
+#include <sensor_msgs/CompressedImage.h>
+
+#include <memory>
+
+#include "cameras/CameraBase.h"
+#include "encoders/NvMediaVp9Encoder.h"
+
+class CameraVp9 : public CameraBase
+{
+public:
+  /**
+   * @brief Constructor, initializes encoder and vp9 image publisher.
+   * @throws NvidiaGmslDriverRosFatalException
+   * @param driveworksApiWrapper
+   * @param config
+   * @param interface
+   * @param link
+   * @param nodehandle
+   */
+  CameraVp9(DriveworksApiWrapper* driveworksApiWrapper, const YAML::Node& config, std::string interface,
+            std::string link, ros::NodeHandle* nodehandle);
+
+  /**
+   * @brief Pushes polled data to the encoder. The encoder will then call it's own callback.
+   * @attention Prerequisite : preprocess()
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  void encode() override;
+
+  /**
+   * @brief Publishes compressed images and camera info to ROS.
+   * @attention Prerequisite : encode()
+   */
+  void publish() override;
+
+  inline static const std::string ENCODER_TYPE = "vp9";
+
+private:
+  constexpr static int DEFAULT_BITRATE = 8000000;
+
+  // params
+  int bitrate_;
+
+  ros::Publisher pub_compressed_;
+  std_msgs::Header header_;
+  sensor_msgs::CompressedImage packet_;
+
+  std::unique_ptr<NvMediaVp9Encoder> encoder_;
+};

--- a/include/encoders/NvMediaH265Encoder.h
+++ b/include/encoders/NvMediaH265Encoder.h
@@ -11,6 +11,11 @@
 #include "exceptions/NvidiaGmslDriverRosFatalException.h"
 #include "framework/Checks.hpp"
 
+/**
+ * @brief Wrapper around NVIDIA Media Interface: NvMedia Image Encode Processing API for H265.
+ * @see
+ * https://docs.nvidia.com/drive/drive-os-5.2.0.0L/drive-os/DRIVE_OS_Linux_SDK_Development_Guide/baggage/nvmedia__iep_8h.html
+ */
 class NvMediaH265Encoder
 {
 public:

--- a/include/encoders/NvMediaH265Encoder.h
+++ b/include/encoders/NvMediaH265Encoder.h
@@ -1,0 +1,110 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#pragma once
+
+#include <dw/image/Image.h>
+#include <nvmedia_iep.h>
+
+#include "DriveworksApiWrapper.h"
+#include "cameras/CameraCommon.h"
+#include "exceptions/NvidiaGmslDriverRosFatalException.h"
+#include "framework/Checks.hpp"
+
+class NvMediaH265Encoder
+{
+public:
+  /**
+   * Constructor.
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  NvMediaH265Encoder(DriveworksApiWrapper* driveworksApiWrapper, int width, int height, int framerate, int bitrate);
+
+  /**
+   * Destructor.
+   */
+  virtual ~NvMediaH265Encoder();
+
+  /**
+   * @brief Feeds a frame into the encoder.
+   */
+  void feed_frame(const dwImageHandle_t* input);
+
+  /**
+   * @brief Polls the encoder and waits for encoded bits availability. Has a 1 frame timeout.
+   * @attention Prerequisite : feed_frame()
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  bool bits_available();
+
+  /**
+   * @brief Pull the bits from the encoder memory to the local image.
+   * @attention Prerequisite : bits_available()
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  void pull_bits();
+
+  /**
+   * @brief Returns a ptr to the image bits pulled from the encoder.
+   */
+  [[nodiscard]] uint8_t* get_buffer();
+
+  /**
+   * @brief Returns the size in bytes of the data stored in the buffer.
+   */
+  [[nodiscard]] uint32_t get_num_bytes_available() const;
+
+private:
+  /** 1 MiB buffer. */
+  static constexpr int BUFFER_SIZE = 1048576;  //
+  /** bits_available timeout (1 frame worth of time). */
+  const uint32_t MILLISECOND_TIMEOUT_ = static_cast<uint32_t>(std::ceil(1000.0 / framerate_));
+
+  DriveworksApiWrapper* driveworksApiWrapper_;
+
+  NvMediaVersion nvMediaVersion_;
+  NvMediaDevice* nvMediaDevice_;
+  NvMediaEncodeInitializeParamsH265 encodeInitParams_{};
+  NvMediaEncodeConfigH265 encodeConfig_{};
+  NvMediaEncodeConfigH265VUIParams* encodeConfigH265VuiParams_{};
+  NvMediaEncodeRCParams rcParams_{};
+  NvMediaEncodePicParamsH265 encodePicParams_{};
+  NvMediaSurfaceType surfaceType_ = camera_common::get_yuv420_block_img_surface();
+  NvMediaIEP* nvMediaIep_;
+  NvMediaStatus nvMediaStatus_;
+
+  dwImageHandle_t imgYuv420Bl_ = DW_NULL_HANDLE;
+  dwImageNvMedia* image_nvmedia_ = nullptr;
+
+  // Buffer
+  std::array<uint8_t, BUFFER_SIZE> buffer_;
+  NvMediaBitstreamBuffer nvMediaBitstreamBuffer_{ buffer_.data(), 0, BUFFER_SIZE };
+
+  uint32_t numBytesAvailable_;
+
+  // config
+  int width_;
+  int height_;
+  int framerate_;
+  int bitrate_;
+
+  /**
+   * @brief Sets the encoder initialization parameters.
+   */
+  void set_encode_init_params();
+
+  /**
+   * @brief Sets the encoder configuration.
+   */
+  void set_encode_config();
+
+  /**
+   * @brief Sets the encoder rate control parameters to use constant bitrate.
+   */
+  void set_encode_config_rcparam();
+
+  /**
+   * @brief Sets the encoder picture parameters.
+   */
+  void set_encode_pic_params();
+};

--- a/include/encoders/NvMediaVp9Encoder.h
+++ b/include/encoders/NvMediaVp9Encoder.h
@@ -1,0 +1,109 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#pragma once
+
+#include <dw/image/Image.h>
+#include <nvmedia_iep.h>
+
+#include "DriveworksApiWrapper.h"
+#include "cameras/CameraCommon.h"
+#include "exceptions/NvidiaGmslDriverRosFatalException.h"
+#include "framework/Checks.hpp"
+
+class NvMediaVp9Encoder
+{
+public:
+  /**
+   * @brief Constructor.
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  NvMediaVp9Encoder(DriveworksApiWrapper* driveworksApiWrapper, int width, int height, int framerate, int bitrate);
+
+  /**
+   * @brief Destructor.
+   */
+  virtual ~NvMediaVp9Encoder();
+
+  /**
+   * @brief Feeds a frame into the encoder.
+   */
+  void feed_frame(const dwImageHandle_t* input);
+
+  /**
+   * @brief Polls the encoder and waits for encoded bits availability. Has a 1 frame timeout.
+   * @attention Prerequisite : feed_frame()
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  bool bits_available();
+
+  /**
+   * @brief Pull the bits from the encoder memory to the local image.
+   * @attention Prerequisite : bits_available()
+   * @throws NvidiaGmslDriverRosFatalException
+   */
+  void pull_bits();
+
+  /**
+   * @brief Returns a ptr to the image bits pulled from the encoder.
+   */
+  [[nodiscard]] uint8_t* get_buffer();
+
+  /**
+   * @brief Returns the size in bytes of the data stored in the buffer.
+   */
+  [[nodiscard]] uint32_t get_num_bytes_available() const;
+
+private:
+  /** 1 MiB buffer. */
+  static constexpr int BUFFER_SIZE = 1048576;  //
+  /** bits_available timeout (1 frame worth of time). */
+  const uint32_t MILLISECOND_TIMEOUT_ = static_cast<uint32_t>(std::ceil(1000.0 / framerate_));
+
+  DriveworksApiWrapper* driveworksApiWrapper_;
+
+  NvMediaVersion nvMediaVersion_;
+  NvMediaDevice* nvMediaDevice_;
+  NvMediaEncodeInitializeParamsVP9 encodeInitParams_{};
+  NvMediaEncodeConfigVP9 encodeConfig_{};
+  NvMediaEncodeRCParams rcParams_{};
+  NvMediaEncodePicParamsVP9 encodePicParams_{};
+  NvMediaSurfaceType surfaceType_ = camera_common::get_yuv420_block_img_surface();
+  NvMediaIEP* nvMediaIep_;
+  NvMediaStatus nvMediaStatus_;
+
+  dwImageHandle_t imgYuv420Bl_ = DW_NULL_HANDLE;
+  dwImageNvMedia* image_nvmedia_ = nullptr;
+
+  // Buffer
+  std::array<uint8_t, BUFFER_SIZE> buffer_;
+  NvMediaBitstreamBuffer nvMediaBitstreamBuffer_{ buffer_.data(), 0, BUFFER_SIZE };
+
+  uint32_t numBytesAvailable_;
+
+  // config
+  int width_;
+  int height_;
+  int framerate_;
+  int bitrate_;
+
+  /**
+   * @brief Sets the encoder initialization parameters.
+   */
+  void set_encode_init_params();
+
+  /**
+   * @brief Sets the encoder configuration.
+   */
+  void set_encode_config();
+
+  /**
+   * @brief Sets the encoder rate control parameters to use constant bitrate.
+   */
+  void set_encode_config_rcparam();
+
+  /**
+   * @brief Sets the encoder picture parameters.
+   */
+  void set_encode_pic_params();
+};

--- a/include/encoders/NvMediaVp9Encoder.h
+++ b/include/encoders/NvMediaVp9Encoder.h
@@ -11,6 +11,11 @@
 #include "exceptions/NvidiaGmslDriverRosFatalException.h"
 #include "framework/Checks.hpp"
 
+/**
+ * @brief Wrapper around NVIDIA Media Interface: NvMedia Image Encode Processing API for VP9.
+ * @see
+ * https://docs.nvidia.com/drive/drive-os-5.2.0.0L/drive-os/DRIVE_OS_Linux_SDK_Development_Guide/baggage/nvmedia__iep_8h.html
+ */
 class NvMediaVp9Encoder
 {
 public:

--- a/launch/nvidia_gmsl_driver_ros.launch
+++ b/launch/nvidia_gmsl_driver_ros.launch
@@ -3,8 +3,8 @@
     <arg name="calib_dir_path" default="$(dirname)/../calib/" doc="Path to calib dir with trailing slash."/>
     <arg name="framerate" default="30" doc="Camera publishing rate."/>
     <arg name="verbose" default="false" doc="{true, false}"/>
-    <arg name="encoder" default="jpg" doc="{jpg, h264}"/>
-    <arg name="bitrate" default="8000000" doc="Output bitrate."/>
+    <arg name="encoder" default="jpg" doc="{h264, h265, jpg, vp9}"/>
+    <arg name="bitrate" default="8000000" doc="Output bitrate, only for h264, h265, vp9."/>
     <arg name="output_width" default="1920" doc="Desired output width."/>
     <arg name="output_height" default="1208" doc="Desired output height."/>
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
     <name>nvidia_gmsl_driver_ros</name>
-    <version>0.0.0</version>
+    <version>0.0.2</version>
     <description>GMSL Driver for Nvidia Platform</description>
 
     <maintainer email="adl@ut.ee">University of Tartu Autonomous Driving Lab</maintainer>

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -48,9 +48,15 @@ void Driver::create_camera(const YAML::Node& config, const std::string& interfac
   if (encoder_name_ == CameraH264::ENCODER_TYPE) {
     camera_vector_.emplace_back(
         std::make_unique<CameraH264>(driveworksApiWrapper_.get(), config, interface, link, &nh_));
+  } else if (encoder_name_ == CameraH265::ENCODER_TYPE) {
+    camera_vector_.emplace_back(
+        std::make_unique<CameraH265>(driveworksApiWrapper_.get(), config, interface, link, &nh_));
   } else if (encoder_name_ == CameraJpg::ENCODER_TYPE) {
     camera_vector_.emplace_back(
         std::make_unique<CameraJpg>(driveworksApiWrapper_.get(), config, interface, link, &nh_));
+  } else if (encoder_name_ == CameraVp9::ENCODER_TYPE) {
+    camera_vector_.emplace_back(
+        std::make_unique<CameraVp9>(driveworksApiWrapper_.get(), config, interface, link, &nh_));
   }
   ROS_INFO_STREAM(camera_vector_.size() << " cameras created.");
 }

--- a/src/cameras/CameraBase.cpp
+++ b/src/cameras/CameraBase.cpp
@@ -88,15 +88,6 @@ void CameraBase::poll()
   }
 }
 
-void CameraBase::run_pipeline()
-{
-  poll();
-  preprocess();
-  encode();
-  CHK_DW(dwSensorCamera_returnFrame(&cameraFrameHandle_));
-  publish();
-}
-
 void CameraBase::preprocess()
 {
   CHK_DW(dwSensorCamera_getImage(&imgOutOfCamera_, DW_CAMERA_OUTPUT_NATIVE_PROCESSED, cameraFrameHandle_));

--- a/src/cameras/CameraBase.cpp
+++ b/src/cameras/CameraBase.cpp
@@ -104,6 +104,5 @@ void CameraBase::preprocess()
 
   if (transformation_needed_) {
     imageTransformer_->transform_image(&imgOutOfCamera_, &imgTransformed_);
-    return;
   }
 }

--- a/src/cameras/CameraH265.cpp
+++ b/src/cameras/CameraH265.cpp
@@ -1,0 +1,43 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#include "cameras/CameraH265.h"
+
+CameraH265::CameraH265(DriveworksApiWrapper* driveworksApiWrapper, const YAML::Node& config, std::string interface,
+                       std::string link, ros::NodeHandle* nodehandle)
+  : CameraBase(driveworksApiWrapper, config, interface, link, nodehandle)
+{
+  nh_.param<int>("bitrate", bitrate_, DEFAULT_BITRATE);
+  ROS_INFO_STREAM("H265 Bitrate: " << bitrate_);
+
+  pub_compressed_ =
+      nh_.advertise<sensor_msgs::CompressedImage>(config_["topic"].as<std::string>() + "/image/" + ENCODER_TYPE, 1);
+
+  encoder_ = std::make_unique<NvMediaH265Encoder>(driveworksApiWrapper_, width_, height_, framerate_, bitrate_);
+}
+
+CameraH265::~CameraH265() {}
+
+void CameraH265::encode()
+{
+  encoder_->feed_frame(transformation_needed_ ? &imgTransformed_ : &imgOutOfCamera_);
+
+  if (!encoder_->bits_available()) {
+    return;
+  }
+  encoder_->pull_bits();
+}
+
+void CameraH265::publish()
+{
+  header_.stamp = ros::Time(static_cast<double>(timestamp_) * 10e-7);
+  header_.frame_id = frame_;
+
+  packet_.data.assign(encoder_->get_buffer(), encoder_->get_buffer() + encoder_->get_num_bytes_available());
+  packet_.header = header_;
+  packet_.format = ENCODER_TYPE;
+  pub_compressed_.publish(packet_);
+
+  camera_info_.header = header_;
+  pub_info_.publish(camera_info_);
+}

--- a/src/cameras/CameraJpg.cpp
+++ b/src/cameras/CameraJpg.cpp
@@ -16,8 +16,6 @@ CameraJpg::CameraJpg(DriveworksApiWrapper* driveworksApiWrapper, const YAML::Nod
 void CameraJpg::encode()
 {
   encoder_->feed_frame(transformation_needed_ ? &imgTransformed_ : &imgOutOfCamera_);
-  encoder_->bits_available();
-  encoder_->pull_bits();
 }
 
 void CameraJpg::publish()
@@ -31,4 +29,18 @@ void CameraJpg::publish()
 
   camera_info_.header = header_;
   pub_info_.publish(camera_info_);
+}
+
+void CameraJpg::run_pipeline()
+{
+  poll();
+  preprocess();
+  encode();
+
+  while (encoder_->bits_available()) {
+    encoder_->pull_bits();
+    publish();
+  }
+
+  CHK_DW(dwSensorCamera_returnFrame(&cameraFrameHandle_));
 }

--- a/src/cameras/CameraVp9.cpp
+++ b/src/cameras/CameraVp9.cpp
@@ -1,0 +1,41 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#include "cameras/CameraVp9.h"
+
+CameraVp9::CameraVp9(DriveworksApiWrapper* driveworksApiWrapper, const YAML::Node& config, std::string interface,
+                     std::string link, ros::NodeHandle* nodehandle)
+  : CameraBase(driveworksApiWrapper, config, interface, link, nodehandle)
+{
+  nh_.param<int>("bitrate", bitrate_, DEFAULT_BITRATE);
+  ROS_INFO_STREAM("VP9 Bitrate: " << bitrate_);
+
+  pub_compressed_ =
+      nh_.advertise<sensor_msgs::CompressedImage>(config_["topic"].as<std::string>() + "/image/" + ENCODER_TYPE, 1);
+
+  encoder_ = std::make_unique<NvMediaVp9Encoder>(driveworksApiWrapper_, width_, height_, framerate_, bitrate_);
+}
+
+void CameraVp9::encode()
+{
+  encoder_->feed_frame(transformation_needed_ ? &imgTransformed_ : &imgOutOfCamera_);
+
+  if (!encoder_->bits_available()) {
+    return;
+  }
+  encoder_->pull_bits();
+}
+
+void CameraVp9::publish()
+{
+  header_.stamp = ros::Time(static_cast<double>(timestamp_) * 10e-7);
+  header_.frame_id = frame_;
+
+  packet_.data.assign(encoder_->get_buffer(), encoder_->get_buffer() + encoder_->get_num_bytes_available());
+  packet_.header = header_;
+  packet_.format = ENCODER_TYPE;
+  pub_compressed_.publish(packet_);
+
+  camera_info_.header = header_;
+  pub_info_.publish(camera_info_);
+}

--- a/src/encoders/NvMediaH264Encoder.cpp
+++ b/src/encoders/NvMediaH264Encoder.cpp
@@ -133,9 +133,10 @@ void NvMediaH264Encoder::pull_bits()
     case NVMEDIA_STATUS_PENDING:
       return;
     default:
-      throw NvidiaGmslDriverRosFatalException(
-          "Error while pulling data from h264 encoder. Error ID: " + std::to_string(nvMediaStatus_) + ", " +
-          NVMEDIA_ERROR_TO_STRING.at(nvMediaStatus_) + ".");
+      std::string msg = "Error while pulling data from h264 encoder. Error ID: " + std::to_string(nvMediaStatus_) +
+                        ", " + NVMEDIA_ERROR_TO_STRING.at(nvMediaStatus_) + ".";
+      ROS_FATAL_STREAM(msg);
+      throw NvidiaGmslDriverRosFatalException(msg);
   }
 }
 

--- a/src/encoders/NvMediaH265Encoder.cpp
+++ b/src/encoders/NvMediaH265Encoder.cpp
@@ -1,0 +1,142 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#include "encoders/NvMediaH265Encoder.h"
+
+NvMediaH265Encoder::NvMediaH265Encoder(DriveworksApiWrapper* driveworksApiWrapper, int width, int height, int framerate,
+                                       int bitrate)
+  : driveworksApiWrapper_(driveworksApiWrapper)
+  , width_(width)
+  , height_(height)
+  , framerate_(framerate)
+  , bitrate_(bitrate)
+{
+  NvMediaIEPGetVersion(&nvMediaVersion_);
+  nvMediaDevice_ = NvMediaDeviceCreate();
+
+  if (!nvMediaDevice_) {
+    throw NvidiaGmslDriverRosFatalException("Unable to create NvMedia device.");
+  }
+
+  set_encode_init_params();
+
+  nvMediaIep_ = NvMediaIEPCreate(nvMediaDevice_, NVMEDIA_IMAGE_ENCODE_HEVC, &encodeInitParams_, surfaceType_, '\0', 16,
+                                 NVMEDIA_ENCODER_INSTANCE_0);
+
+  if (!nvMediaIep_) {
+    throw NvidiaGmslDriverRosFatalException("Unable to create NvMedia IEP.");
+  }
+
+  set_encode_config();
+  set_encode_config_rcparam();
+  set_encode_pic_params();
+
+  CHK_NVM(NvMediaIEPSetConfiguration(nvMediaIep_, &encodeConfig_));
+
+  nvMediaBitstreamBuffer_.bitstream = buffer_.data();
+
+  dwImage_create(&imgYuv420Bl_, camera_common::get_yuv420_block_img_prop(width_, height_),
+                 driveworksApiWrapper_->context_handle_);
+}
+
+NvMediaH265Encoder::~NvMediaH265Encoder()
+{
+  NvMediaIEPDestroy(nvMediaIep_);
+  dwImage_destroy(imgYuv420Bl_);
+}
+
+void NvMediaH265Encoder::set_encode_init_params()
+{
+  encodeInitParams_.encodeWidth = static_cast<uint16_t>(width_);
+  encodeInitParams_.encodeHeight = static_cast<uint16_t>(height_);
+  encodeInitParams_.frameRateNum = framerate_;
+  encodeInitParams_.frameRateDen = 1;
+  encodeInitParams_.profile = 0;
+  encodeInitParams_.level = 0;
+  encodeInitParams_.maxNumRefFrames = 2;
+  encodeInitParams_.enableExternalMEHints = NVMEDIA_FALSE;
+  encodeInitParams_.useBFramesAsRef = 0;
+  encodeInitParams_.enableAllIFrames = 0;
+}
+
+void NvMediaH265Encoder::set_encode_config()
+{
+  encodeConfig_.enableWeightedPrediction = 0;
+  encodeConfig_.features = 0;
+  encodeConfig_.gopLength = encodeInitParams_.frameRateNum / encodeInitParams_.frameRateDen;
+  encodeConfig_.idrPeriod = encodeConfig_.gopLength;
+  encodeConfig_.repeatSPSPPS = NVMEDIA_ENCODE_SPSPPS_REPEAT_IDR_FRAMES;
+  encodeConfig_.quality = NVMEDIA_ENCODE_QUALITY_L0;
+  encodeConfig_.numSliceCountMinus1 = 0;
+  encodeConfig_.intraRefreshCnt = 0;
+  encodeConfig_.h265VUIParameters = encodeConfigH265VuiParams_;
+}
+
+void NvMediaH265Encoder::set_encode_config_rcparam()
+{
+  rcParams_.rateControlMode = NVMEDIA_ENCODE_PARAMS_RC_CBR;
+  rcParams_.numBFrames = 0;
+  rcParams_.params.cbr.averageBitRate = bitrate_;
+  rcParams_.params.cbr.vbvBufferSize = 0;
+  rcParams_.params.cbr.vbvInitialDelay = 0;
+  encodeConfig_.rcParams = rcParams_;
+}
+
+void NvMediaH265Encoder::set_encode_pic_params()
+{
+  encodePicParams_.pictureType = NVMEDIA_ENCODE_PIC_TYPE_AUTOSELECT;
+  encodePicParams_.encodePicFlags = 0b0001;
+  encodePicParams_.frameRateDen = encodeInitParams_.frameRateDen;
+  encodePicParams_.frameRateNum = encodeInitParams_.frameRateNum;
+  encodePicParams_.nextBFrames = 0;
+  encodePicParams_.rcParams = encodeConfig_.rcParams;
+}
+
+void NvMediaH265Encoder::feed_frame(const dwImageHandle_t* input)
+{
+  dwImage_copyConvert(imgYuv420Bl_, *input, driveworksApiWrapper_->context_handle_);
+  CHK_DW(dwImage_getNvMedia(&image_nvmedia_, imgYuv420Bl_));
+  CHK_NVM(
+      NvMediaIEPFeedFrame(nvMediaIep_, image_nvmedia_->img, nullptr, &encodePicParams_, NVMEDIA_ENCODER_INSTANCE_0));
+}
+
+bool NvMediaH265Encoder::bits_available()
+{
+  nvMediaStatus_ = NvMediaIEPBitsAvailable(nvMediaIep_, &numBytesAvailable_, NVMEDIA_ENCODE_BLOCKING_TYPE_IF_PENDING,
+                                           MILLISECOND_TIMEOUT_);
+
+  if (nvMediaStatus_ == NVMEDIA_STATUS_OK && numBytesAvailable_ > 0) {
+    return true;
+  }
+
+  if (nvMediaStatus_ == NVMEDIA_STATUS_BAD_PARAMETER) {
+    throw NvidiaGmslDriverRosFatalException("Bad parameters for NvMediaIEPBitsAvailable");
+  }
+
+  return false;
+}
+
+void NvMediaH265Encoder::pull_bits()
+{
+  nvMediaStatus_ = NvMediaIEPGetBitsEx(nvMediaIep_, &numBytesAvailable_, 1, &nvMediaBitstreamBuffer_, nullptr);
+
+  switch (nvMediaStatus_) {
+    case NVMEDIA_STATUS_OK:
+    case NVMEDIA_STATUS_INSUFFICIENT_BUFFERING:
+    case NVMEDIA_STATUS_PENDING:
+      return;
+    default:
+      throw NvidiaGmslDriverRosFatalException(
+          "Error while pulling data from h265 encoder. Error ID: " + std::to_string(nvMediaStatus_) + ".");
+  }
+}
+
+uint8_t* NvMediaH265Encoder::get_buffer()
+{
+  return buffer_.data();
+}
+
+uint32_t NvMediaH265Encoder::get_num_bytes_available() const
+{
+  return numBytesAvailable_;
+}

--- a/src/encoders/NvMediaH265Encoder.cpp
+++ b/src/encoders/NvMediaH265Encoder.cpp
@@ -126,8 +126,10 @@ void NvMediaH265Encoder::pull_bits()
     case NVMEDIA_STATUS_PENDING:
       return;
     default:
-      throw NvidiaGmslDriverRosFatalException(
-          "Error while pulling data from h265 encoder. Error ID: " + std::to_string(nvMediaStatus_) + ".");
+      std::string msg = "Error while pulling data from h265 encoder. Error ID: " + std::to_string(nvMediaStatus_) +
+                        ", " + NVMEDIA_ERROR_TO_STRING.at(nvMediaStatus_) + ".";
+      ROS_FATAL_STREAM(msg);
+      throw NvidiaGmslDriverRosFatalException(msg);
   }
 }
 

--- a/src/encoders/NvMediaVp9Encoder.cpp
+++ b/src/encoders/NvMediaVp9Encoder.cpp
@@ -1,0 +1,135 @@
+// Created by Maxandre Ogeret.
+// (c) 2022 University of Tartu - Autonomous Driving Lab.
+
+#include "encoders/NvMediaVp9Encoder.h"
+
+NvMediaVp9Encoder::NvMediaVp9Encoder(DriveworksApiWrapper* driveworksApiWrapper, int width, int height, int framerate,
+                                     int bitrate)
+  : driveworksApiWrapper_(driveworksApiWrapper)
+  , width_(width)
+  , height_(height)
+  , framerate_(framerate)
+  , bitrate_(bitrate)
+{
+  NvMediaIEPGetVersion(&nvMediaVersion_);
+  nvMediaDevice_ = NvMediaDeviceCreate();
+
+  if (!nvMediaDevice_) {
+    throw NvidiaGmslDriverRosFatalException("Unable to create NvMedia device.");
+  }
+
+  set_encode_init_params();
+
+  nvMediaIep_ = NvMediaIEPCreate(nvMediaDevice_, NVMEDIA_IMAGE_ENCODE_VP9, &encodeInitParams_, surfaceType_, '\0', 100,
+                                 NVMEDIA_ENCODER_INSTANCE_0);
+
+  if (!nvMediaIep_) {
+    throw NvidiaGmslDriverRosFatalException("Unable to create NvMedia IEP.");
+  }
+
+  set_encode_config();
+  set_encode_config_rcparam();
+  set_encode_pic_params();
+
+  CHK_NVM(NvMediaIEPSetConfiguration(nvMediaIep_, &encodeConfig_));
+
+  nvMediaBitstreamBuffer_.bitstream = buffer_.data();
+
+  dwImage_create(&imgYuv420Bl_, camera_common::get_yuv420_block_img_prop(width_, height_),
+                 driveworksApiWrapper_->context_handle_);
+}
+
+NvMediaVp9Encoder::~NvMediaVp9Encoder()
+{
+  NvMediaIEPDestroy(nvMediaIep_);
+  dwImage_destroy(imgYuv420Bl_);
+}
+
+void NvMediaVp9Encoder::set_encode_init_params()
+{
+  encodeInitParams_.encodeWidth = static_cast<uint16_t>(width_);
+  encodeInitParams_.encodeHeight = static_cast<uint16_t>(height_);
+  encodeInitParams_.frameRateNum = framerate_;
+  encodeInitParams_.frameRateDen = 1;
+  encodeInitParams_.maxNumRefFrames = 2;
+  encodeInitParams_.enableExternalMEHints = NVMEDIA_FALSE;
+}
+
+void NvMediaVp9Encoder::set_encode_config()
+{
+  encodeConfig_.features = 0;
+  encodeConfig_.gopLength = encodeInitParams_.frameRateNum / encodeInitParams_.frameRateDen;
+  encodeConfig_.idrPeriod = encodeConfig_.gopLength;
+}
+
+void NvMediaVp9Encoder::set_encode_config_rcparam()
+{
+  rcParams_.rateControlMode = NVMEDIA_ENCODE_PARAMS_RC_CBR;
+  rcParams_.numBFrames = 0;
+  rcParams_.params.cbr.averageBitRate = bitrate_;
+  rcParams_.params.cbr.vbvBufferSize = 0;
+  rcParams_.params.cbr.vbvInitialDelay = 0;
+  encodeConfig_.rcParams = rcParams_;
+}
+
+void NvMediaVp9Encoder::set_encode_pic_params()
+{
+  encodePicParams_.pictureType = NVMEDIA_ENCODE_PIC_TYPE_AUTOSELECT;
+  encodePicParams_.nextBFrames = 0;
+  encodePicParams_.encodePicFlags = 0b0001;
+  encodePicParams_.rcParams = encodeConfig_.rcParams;
+}
+
+void NvMediaVp9Encoder::feed_frame(const dwImageHandle_t* input)
+{
+  dwImage_copyConvert(imgYuv420Bl_, *input, driveworksApiWrapper_->context_handle_);
+  CHK_DW(dwImage_getNvMedia(&image_nvmedia_, imgYuv420Bl_));
+
+  nvMediaStatus_ =
+      NvMediaIEPFeedFrame(nvMediaIep_, image_nvmedia_->img, nullptr, &encodePicParams_, NVMEDIA_ENCODER_INSTANCE_0);
+
+  if (nvMediaStatus_ == NVMEDIA_STATUS_INSUFFICIENT_BUFFERING) {
+    return;
+  }
+  CHK_NVM(nvMediaStatus_);
+}
+
+bool NvMediaVp9Encoder::bits_available()
+{
+  nvMediaStatus_ = NvMediaIEPBitsAvailable(nvMediaIep_, &numBytesAvailable_, NVMEDIA_ENCODE_BLOCKING_TYPE_IF_PENDING,
+                                           MILLISECOND_TIMEOUT_);
+
+  if (nvMediaStatus_ == NVMEDIA_STATUS_OK && numBytesAvailable_ > 0) {
+    return true;
+  }
+
+  if (nvMediaStatus_ == NVMEDIA_STATUS_BAD_PARAMETER) {
+    throw NvidiaGmslDriverRosFatalException("Bad parameters for NvMediaIEPBitsAvailable");
+  }
+  return false;
+}
+
+void NvMediaVp9Encoder::pull_bits()
+{
+  nvMediaStatus_ = NvMediaIEPGetBitsEx(nvMediaIep_, &numBytesAvailable_, 1, &nvMediaBitstreamBuffer_, nullptr);
+
+  switch (nvMediaStatus_) {
+    case NVMEDIA_STATUS_OK:
+    case NVMEDIA_STATUS_INSUFFICIENT_BUFFERING:
+    case NVMEDIA_STATUS_PENDING:
+      return;
+    default:
+      throw NvidiaGmslDriverRosFatalException(
+          "Error while pulling data from VP9 encoder. Error ID: " + std::to_string(nvMediaStatus_) + ".");
+  }
+}
+
+uint8_t* NvMediaVp9Encoder::get_buffer()
+{
+  return buffer_.data();
+}
+
+uint32_t NvMediaVp9Encoder::get_num_bytes_available() const
+{
+  return numBytesAvailable_;
+}

--- a/src/encoders/NvMediaVp9Encoder.cpp
+++ b/src/encoders/NvMediaVp9Encoder.cpp
@@ -119,8 +119,10 @@ void NvMediaVp9Encoder::pull_bits()
     case NVMEDIA_STATUS_PENDING:
       return;
     default:
-      throw NvidiaGmslDriverRosFatalException(
-          "Error while pulling data from VP9 encoder. Error ID: " + std::to_string(nvMediaStatus_) + ".");
+      std::string msg = "Error while pulling data from vp9 encoder. Error ID: " + std::to_string(nvMediaStatus_) +
+                        ", " + NVMEDIA_ERROR_TO_STRING.at(nvMediaStatus_) + ".";
+      ROS_FATAL_STREAM(msg);
+      throw NvidiaGmslDriverRosFatalException(msg);
   }
 }
 


### PR DESCRIPTION
Adding h265 and VP9 encoders.

- [ ] Todo: Once https://github.com/UT-ADL/nvidia_gmsl_driver_ros/pull/1 is merged, this PR has to be redirected to upstream's main.